### PR TITLE
Fix t2 push default slimPath so app start finds it

### DIFF
--- a/bin/tessel-2.js
+++ b/bin/tessel-2.js
@@ -167,7 +167,7 @@ makeCommand('push')
     help: 'Bundle only the required modules'
   })
   .option('slimPath', {
-    default: 'build.js'
+    default: 'index.js'
   })
   .help('Pushes the file/dir to Flash memory to be run anytime the Tessel is powered, runs the file immediately once the file is copied over');
 


### PR DESCRIPTION
When doing a slim build, the resulting script should be laid down as index.js so that when /app/start does its exec node . there is an index.js in place.
